### PR TITLE
bug: f64/f32 unit conversions used to point in wrong direction

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,13 +40,13 @@ impl_mul_power_of_ten!(i8, i16, i32, i64, isize, u8, u16, u32, u64, u128);
 
 impl MulPowerOfTen for f32 {
     fn mul_power_of_ten(self, exp: i8) -> Self {
-        self * 10f32.powi(exp as i32)
+        self * 10f32.powi(-exp as i32)
     }
 }
 
 impl MulPowerOfTen for f64 {
     fn mul_power_of_ten(self, exp: i8) -> Self {
-        self * 10f64.powi(exp as i32)
+        self * 10f64.powi(-exp as i32)
     }
 }
 


### PR DESCRIPTION
Fixes f32-ization of `fn convert()`'s doctest:

```rust
# use uy::{si, Quantity};
let a: Quantity<f32, si::m> = Quantity::new(3.0);
let b: Quantity<f32, si::milli<si::m>> = a.convert();
assert_eq!(*b, 3000.0);
```

Very nice library! Clean and simple, no scope creep, macro hell doesn't leak out. :)